### PR TITLE
Implemented Role classes for User

### DIFF
--- a/server/app/cobase/DBTables.scala
+++ b/server/app/cobase/DBTables.scala
@@ -6,7 +6,7 @@ import com.github.tototoshi.slick.PostgresJodaSupport._
 import cobase.authentication.AuthenticationToken
 import cobase.group.Group
 import cobase.post.Post
-import cobase.user.{User, Subscription}
+import cobase.user.{UserRole, Role, User, Subscription}
 import org.joda.time.DateTime
 import slick.driver.JdbcProfile
 
@@ -19,7 +19,7 @@ trait DBTables {
     def id = column[UUID]("id", O.PrimaryKey, O.SqlType("UUID"))
     def email = column[String]("email")
     def password = column[String]("password")
-    def role = column[String]("role")
+    def role = column[Role]("role")
 
     def created = column[DateTime]("created")
 
@@ -40,6 +40,11 @@ trait DBTables {
 
     def * = (id, email, password, role, created, verificationToken, verified, firstName, lastName, avatarURL, passwordResetToken, passwordResetRequested, passwordResetUsed) <> (User.tupled, User.unapply)
   }
+
+  implicit val roleMapper = MappedColumnType.base[Role, String](
+    role => role.name,
+    name => Role.fromName(name).getOrElse(UserRole)
+  )
 
   class AuthenticationTokens(tag: Tag) extends Table[AuthenticationToken](tag, "authentication_tokens") {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)

--- a/server/app/cobase/authentication/AuthenticationResponse.scala
+++ b/server/app/cobase/authentication/AuthenticationResponse.scala
@@ -16,6 +16,6 @@ object AuthenticationResponse {
   implicit val writes = Json.format[AuthenticationResponse]
 
   def fromAuthenticatedUser(u: AuthenticatedUser): AuthenticationResponse = {
-    this(u.user.id, u.user.username, u.user.role, u.token, u.user.fullName)
+    this(u.user.id, u.user.username, u.user.role.name, u.token, u.user.fullName)
   }
 }

--- a/server/app/cobase/user/RegisterUserData.scala
+++ b/server/app/cobase/user/RegisterUserData.scala
@@ -8,7 +8,7 @@ case class RegisterUserData(
   id: UUID,
   username: String,
   hashedPassword: String,
-  role: String,
+  role: Role,
   created: DateTime,
   verificationToken: String
 )

--- a/server/app/cobase/user/RegistrationRequest.scala
+++ b/server/app/cobase/user/RegistrationRequest.scala
@@ -14,10 +14,6 @@ object RegistrationRequest {
   implicit val reads: Reads[RegistrationRequest] = (
     (__ \ "username").read[String](email) and
     (__ \ "password").read[String](minLength[String](8)) and
-    (__ \ "role").read[String](minLength[String](1))
-      .map(_ match {
-        case "admin" => "admin"
-        case _ => "user"
-      })
+    (__ \ "role").read[String](verifying[String](role => Role.fromName(role).isSuccess))
   )(RegistrationRequest.apply _)
 }

--- a/server/app/cobase/user/RegistrationResponse.scala
+++ b/server/app/cobase/user/RegistrationResponse.scala
@@ -15,6 +15,6 @@ object RegistrationResponse {
   implicit val writes = Json.format[RegistrationResponse]
 
   def fromUser(user: User): RegistrationResponse = {
-    this(user.id, user.username, user.role, user.fullName)
+    this(user.id, user.username, user.role.name, user.fullName)
   }
 }

--- a/server/app/cobase/user/Role.scala
+++ b/server/app/cobase/user/Role.scala
@@ -1,0 +1,24 @@
+package cobase.user
+
+import scala.util.{Failure, Success, Try}
+
+sealed trait Role {
+  def name: String
+}
+
+object Role {
+  def fromName(name: String): Try[Role] = {
+    name match {
+      case UserRole.name => Success(UserRole)
+      case AdminRole.name => Success(AdminRole)
+      case _ => Failure(new Exception("invalid role"))
+    }
+  }
+}
+
+case object UserRole extends Role {
+  val name = "user"
+}
+case object AdminRole extends Role {
+  val name = "admin"
+}

--- a/server/app/cobase/user/User.scala
+++ b/server/app/cobase/user/User.scala
@@ -8,7 +8,7 @@ case class User(
   id: UUID,
   username: String,
   password: String,
-  role: String,
+  role: Role,
   created: DateTime,
   verificationToken: String,
   verified: Option[DateTime] = None,

--- a/server/app/cobase/user/UserService.scala
+++ b/server/app/cobase/user/UserService.scala
@@ -23,7 +23,7 @@ class UserService @Inject() (
         UUID.randomUUID(),
         data.username,
         password,
-        data.role,
+        Role.fromName(data.role).getOrElse(UserRole),
         DateTime.now(),
         verificationToken
       ))


### PR DESCRIPTION
Plain SQL has to be written to make PostgreSQL co-operate with `role` enum.
