### PR TITLE
Add CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Feel free to join the conversation on channel #cobase-pro @ freenode.net
 
 1. `cd client`
 2. Install npm components: `npm install`
-3. Copy frontend config and configure it: `cp conf/config.example.js config.js`
+3. Copy frontend config and configure it: `cp conf/config.example.js conf/config.js`
 4. Start the client development server: `npm start`
 5. Open browser (http://cobasepro.tunk.io)
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Feel free to join the conversation on channel #cobase-pro @ freenode.net
 
 1. `cd client`
 2. Install npm components: `npm install`
-3. Start the client development server: `npm start`
-4. Open browser (http://cobasepro.tunk.io)
+3. Copy frontend config and configure it: `cp conf/config.example.js config.js`
+4. Start the client development server: `npm start`
+5. Open browser (http://cobasepro.tunk.io)
 
 
 ## Database migrations

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 public/dist/*
 webpack-assets/
 public/webpack-assets
+conf/config.js

--- a/client/conf/config.example.js
+++ b/client/conf/config.example.js
@@ -1,0 +1,4 @@
+export default {
+  // The backend API (e.g. http://cobase.tunk.io/api)
+  apiUrl: '/api'
+};

--- a/client/conf/config.js
+++ b/client/conf/config.js
@@ -1,3 +1,0 @@
-export default {
-  apiUrl: '/api'
-};

--- a/client/src/devServer.js
+++ b/client/src/devServer.js
@@ -6,15 +6,21 @@ var config = require('../webpack.config');
 var app = express();
 var compiler = webpack(config);
 
-app.use(require('webpack-dev-middleware')(compiler, {
+var devMiddleware = require('webpack-dev-middleware')(compiler, {
   noInfo: true,
   publicPath: config.output.publicPath
-}));
+});
+
+app.use(devMiddleware);
 
 app.use(require('webpack-hot-middleware')(compiler));
 
 app.get('*', function(req, res) {
-  res.sendFile(path.join(__dirname, 'index.html'));
+  res.end(
+    devMiddleware.fileSystem.readFileSync(
+      path.join(config.output.path, 'index.html')
+    )
+  );
 });
 
 app.listen(3000, 'localhost', function(err) {

--- a/server/app/cobase/play/Filters.scala
+++ b/server/app/cobase/play/Filters.scala
@@ -6,10 +6,11 @@ import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
 import play.filters.csrf.CSRFFilter
 import play.filters.headers.SecurityHeadersFilter
+import play.filters.cors.CORSFilter
 
 /**
  * Provides filters.
  */
-class Filters @Inject() (csrfFilter: CSRFFilter, securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
-  override def filters: Seq[EssentialFilter] = Seq(csrfFilter, securityHeadersFilter)
+class Filters @Inject() (csrfFilter: CSRFFilter, securityHeadersFilter: SecurityHeadersFilter, corsFilter: CORSFilter) extends HttpFilters {
+  override def filters: Seq[EssentialFilter] = Seq(csrfFilter, securityHeadersFilter, corsFilter)
 }


### PR DESCRIPTION
 There were multiple problems when serving frontend through `express` and `webpack-dev-middleware` and having a backend on a different hostname.
- Add CORS support as a filter (https://www.playframework.com/documentation/2.4.x/CorsFilter)
- Make API configurable on the frontend
- Fix blank screen when refreshing page, now every request goes through `webpack-dev-middleware` and React Router knows what components to render
